### PR TITLE
Add message to import failure

### DIFF
--- a/plugins/autobreak/autobreak.py
+++ b/plugins/autobreak/autobreak.py
@@ -10,7 +10,9 @@ from operator import itemgetter
 try:
     import staplegraph
     nx = True
-except:
+except Exception as e:
+    print("AutoBreak warning - Could not import staplegraph!")
+    print(e)
     nx = False
 
 token_cache = {}


### PR DESCRIPTION
Hello,

We just had the problem that autobreak was not working due to a missing networkx dependency.
Therefore, importing staplegraph failed and breakStaples was not working.
It might be helpful for the user to fix such problems, if the actual error message of the exception would be printed.

best,
Markus